### PR TITLE
Allow unsetting Gnuplot variables

### DIFF
--- a/test/test_gnuplot.rb
+++ b/test/test_gnuplot.rb
@@ -56,11 +56,13 @@ class PlotTest < Test::Unit::TestCase
     plot = Gnuplot::Plot.new do |p|
       p.set "output", "'foo'"
       p.set "terminal", "postscript enhanced"
+      p.unset "border"
     end
 
-    assert( plot.sets ==
-		 [ ["output", "'foo'"], 
-		   ["terminal", "postscript enhanced"] ] )
+    assert( plot.settings ==
+		 [ [:set, "output", "'foo'"], 
+		   [:set, "terminal", "postscript enhanced"],
+                   [:unset, "border"] ] )
     
 
     assert( plot.to_gplot, \
@@ -76,6 +78,16 @@ class PlotTest < Test::Unit::TestCase
 
     plot.set "title", "'foo'"
     assert "'foo'", plot["title"]
+  end
+
+  def test_unset
+    plot = Gnuplot::Plot.new do |p|
+      p.unset "title"
+    end
+    assert_nil plot["title"]
+
+    plot.unset "title"
+    assert_nil plot["title"]
   end
 
 end


### PR DESCRIPTION
This change adds a method Gnuplot::Plot.unset(var) to unset the Gnuplot variable var. As
the order of sets and unsets are important for Gnuplot, a new array "settings" was
introduced in which the set and unset tasks are accumulated.
