### PR TITLE
Bugfix for SPlot

### DIFF
--- a/lib/gnuplot.rb
+++ b/lib/gnuplot.rb
@@ -182,8 +182,9 @@ module Gnuplot
     end
     
     def to_gplot (io = "")
-      @sets.each { |var, val| io << "set #{var} #{val}\n" }
-
+      @settings.each do |setting|
+          io << setting.map(&:to_s).join(" ") << "\n"
+      end
       io
     end
 


### PR DESCRIPTION
Hi, rdp!

In SPlot implementation was find old code remains. They has generate an exception when we used SPlot object.
I'm trying to fix this bug, but Ruby is Terra Inkognita for me. I hope i'm fixing it correct.

Yours sincerely
TheKnight

P.S:I'm sorry about my English.
