### PR TITLE
Exposed DataSet#index property

### DIFF
--- a/lib/gnuplot.rb
+++ b/lib/gnuplot.rb
@@ -210,11 +210,11 @@ module Gnuplot
   # @todo Use the delegator to delegate to the data property.
 
   class DataSet 
-    attr_accessor :title, :with, :using, :data, :linewidth, :linecolor, :matrix, :smooth, :axes
+    attr_accessor :title, :with, :using, :data, :linewidth, :linecolor, :matrix, :smooth, :axes, :index
   
     def initialize (data = nil)
       @data = data
-      @title = @with = @using = @linewidth = @linecolor = @matrix = @smooth = @axes = nil # avoid warnings
+      @title = @with = @using = @linewidth = @linecolor = @matrix = @smooth = @axes = @index = nil # avoid warnings
       yield self if block_given?
     end
         
@@ -227,6 +227,8 @@ module Gnuplot
       # Order of these is important or gnuplot barfs on 'em
 
       io << ( (@data.instance_of? String) ? @data : "'-'" )
+
+      io << " index #{@index}" if @index
 
       io << " using #{@using}" if @using
      


### PR DESCRIPTION
Use of index property is required for me to be able to draw a curve based on a simple dataset of values (x, y) :

dataset = Gnuplot::DataSet.new( [x, y] ) do |ds|
  ds.with = "linespoints"
  ds.notitle
  ds.using = "1:2"
  ds.index = 0
end
