### PR TITLE
Added helper to create linestyles

### DIFF
--- a/test/test_gnuplot.rb
+++ b/test/test_gnuplot.rb
@@ -90,6 +90,34 @@ class PlotTest < Test::Unit::TestCase
     assert_nil plot["title"]
   end
 
+  def test_style
+    plot = Gnuplot::Plot.new do |p|
+      s1 = p.style do |s|
+        s.ls = 1
+        s.lt = 1
+        s.lc = 1
+        s.pt = 1
+        s.ps = 1
+      end
+      assert s1.to_s == "set style line 1 ls 1 lt 1 lc 1 pt 1 ps 1", "correct style definition"
+      assert s1.index == 1, "set index correctly"
+
+      s2 = p.style do |s|
+        s.ls = 2
+      end
+      assert s2.to_s == "set style line 2 ls 2", "correct style definition"
+      assert s2.index == 2, "index must be incremented"
+
+      ds = Gnuplot::DataSet.new do |ds|
+        ds.with = "lines" 
+        ds.linestyle = s1
+        ds.data = [ [0, 1, 2], [1, 2, 5] ]
+      end
+
+      assert ds.plot_args == "'-' with lines linestyle 1", "convert linestyle to index" # index of s1
+    end
+  end
+
 end
 
 


### PR DESCRIPTION
This commit adds a class Style to add linestyles to the plot. Usage

```
require "gnuplot"

Gnuplot.open do |gp|
  Gnuplot::Plot.new( gp ) do |plot|
    plot.xrange "[-10:10]"
    plot.title  "Sin Wave Example"
    plot.ylabel "x"
    plot.xlabel "sin(x)"

    # Create the style
    s = plot.style do |style|
        style.lt = 1
        style.lc = 3
    end

    plot.data << Gnuplot::DataSet.new( "sin(x)" ) do |ds|
      ds.with = "lines"
      # Use the style in a plot
      ds.ls = s
    end
  end
end
```
