### PR TITLE
Handle empty arrays in Array#to_gplot.

### DIFF
--- a/lib/gnuplot.rb
+++ b/lib/gnuplot.rb
@@ -1,21 +1,21 @@
 # Methods and variables for interacting with the gnuplot process.  Most of
 # these methods are for sending data to a gnuplot process, not for reading from
-# it.  Most of the methods are implemented as added methods to the built in 
+# it.  Most of the methods are implemented as added methods to the built in
 # classes.
 
 require 'matrix'
- 
+
 module Gnuplot
 
   # Trivial implementation of the which command that uses the PATH environment
   # variable to attempt to find the given application.  The application must
   # be executable and reside in one of the directories in the PATH environment
   # to be found.  The first match that is found will be returned.
-  # 
+  #
   # bin [String] The name of the executable to search for.
-  # 
+  #
   # Return the full path to the first match or nil if no match is found.
-  # 
+  #
   def Gnuplot.which ( bin )
     if RUBY_PLATFORM =~ /mswin|mingw/
       all = [bin, bin + '.exe']
@@ -41,18 +41,18 @@ module Gnuplot
 
     # This is an implementation that works when the which command is
     # available.
-    # 
+    #
     # IO.popen("which #{bin}") { |io| return io.readline.chomp }
 
     return nil
-  end 
+  end
 
   # Find the path to the gnuplot executable.  The name of the executable can
   # be specified using the RB_GNUPLOT environment variable but will default to
-  # the command 'gnuplot'.  
-  # 
+  # the command 'gnuplot'.
+  #
   # persist [bool] Add the persist flag to the gnuplot executable
-  # 
+  #
   # Return the path to the gnuplot executable or nil if one cannot be found.
   def Gnuplot.gnuplot( persist = true )
     exe_loc = which( ENV['RB_GNUPLOT'] || 'gnuplot' )
@@ -61,15 +61,15 @@ module Gnuplot
     cmd += " -persist" if persist
     cmd
   end
-    
+
   # Open a gnuplot process that exists in the current PATH.  If the persist
   # flag is true then the -persist flag is added to the command line.  The
-  # path to the gnuplot executable is determined using the 'which' command. 
+  # path to the gnuplot executable is determined using the 'which' command.
   #
   # See the gnuplot documentation for information on the persist flag.
   #
   # <b>todo</b> Add a method to pass the gnuplot path to the function.
-  
+
   def Gnuplot.open( persist=true )
     cmd = Gnuplot.gnuplot( persist )
     IO::popen( cmd, "w+") { |io|
@@ -77,11 +77,11 @@ module Gnuplot
       io.close_write
       @output = io.read
     }
-    return @output	
+    return @output
   end
-  
-    
-    
+
+
+
   # Holds command information and performs the formatting of that command
   # information to a Gnuplot process.  When constructing a new plot for
   # gnuplot, this is the first object that must be instantiated.  On this
@@ -101,7 +101,7 @@ module Gnuplot
       yield self if block_given?
       puts "writing this to gnuplot:\n" + to_gplot + "\n" if $VERBOSE
 
-      if io    
+      if io
         io << to_gplot
         io << store_datasets
       end
@@ -119,7 +119,7 @@ module Gnuplot
 
     # Set a variable to the given value.  +Var+ must be a gnuplot variable and
     # +value+ must be the value to set it to.  Automatic quoting will be
-    # performed if the variable requires it.  
+    # performed if the variable requires it.
     #
     # This is overloaded by the +method_missing+ method so see that for more
     # readable code.
@@ -230,7 +230,7 @@ module Gnuplot
         v = @data.collect { |ds| ds.to_gplot }
       	io << v.compact.join("e\n")
       end
-      
+
       io
     end
   end
@@ -243,7 +243,7 @@ module Gnuplot
     def initialize (io = nil, cmd = "splot")
       super
     end
-    
+
     # Currently using the implementation from parent class Plot.
     # Leaving the method explicit here, though, as to allow an specific
     # implementation for SPlot in the future.
@@ -258,7 +258,7 @@ module Gnuplot
   # has a reference to the actual data being plotted as well as settings that
   # control the "plot" command.  The data object must support the to_gplot
   # command.
-  # 
+  #
   # +data+ The data that will be plotted.  The only requirement is that the
   # object understands the to_gplot method.
   #
@@ -269,25 +269,25 @@ module Gnuplot
   #
   # @todo Use the delegator to delegate to the data property.
 
-  class DataSet 
+  class DataSet
     attr_accessor :title, :with, :using, :data, :linewidth, :linecolor, :matrix, :smooth, :axes, :index, :linestyle
 
     alias :ls :linestyle
     alias :ls= :linestyle=
-  
+
     def initialize (data = nil)
       @data = data
       @linestyle = @title = @with = @using = @linewidth = @linecolor = @matrix =
           @smooth = @axes = @index = nil # avoid warnings
       yield self if block_given?
     end
-        
+
     def notitle
       @title = "notitle"
     end
 
     def plot_args (io = "")
-      
+
       # Order of these is important or gnuplot barfs on 'em
 
       io << ( (@data.instance_of? String) ? @data : "'-'" )
@@ -295,13 +295,13 @@ module Gnuplot
       io << " index #{@index}" if @index
 
       io << " using #{@using}" if @using
-     
+
       io << " axes #{@axes}" if @axes
- 
+
       io << case @title
             when /notitle/ then " notitle"
             when nil       then ""
-            else " title '#{@title}'" 
+            else " title '#{@title}'"
             end
 
       io << " matrix" if @matrix
@@ -328,19 +328,20 @@ module Gnuplot
       else @data.to_gsplot
       end
     end
-    
+
   end
 end
 
 class Array
   def to_gplot
-    if ( self[0].kind_of? Array ) then
+    return "" if self.empty?
+
+    case self[0]
+    when Array
       tmp = self[0].zip( *self[1..-1] )
       tmp.collect { |a| a.join(" ") }.join("\n") + "\ne"
-    elsif ( self[0].kind_of? Numeric ) then
-      s = ""
-      self.length.times { |i| s << "#{self[i]}\n" }
-      s
+    when Numeric
+      self.join("\n")
     else
       self[0].zip( *self[1..-1] ).to_gplot
     end
@@ -348,7 +349,7 @@ class Array
 
   def to_gsplot
     f = ""
-    
+
     if ( self[0].kind_of? Array ) then
       x = self[0]
       y = self[1]
@@ -365,16 +366,16 @@ class Array
     else
       self[0].zip( *self[1..-1] ).to_gsplot
     end
-    
+
     f
   end
 end
-   
+
 class Matrix
   def to_gplot (x = nil, y = nil)
     xgrid = x || (0...self.column_size).to_a
     ygrid = y || (0...self.row_size).to_a
-  
+
     f = ""
     ygrid.length.times do |j|
       y = ygrid[j]
@@ -384,7 +385,7 @@ class Matrix
         end
       end
     end
-    
+
     f
   end
 

--- a/test/test_gnuplot.rb
+++ b/test/test_gnuplot.rb
@@ -4,13 +4,21 @@ require '../lib/gnuplot'
 require 'test/unit'
 
 class StdDataTest < Test::Unit::TestCase
-    
+
   def test_array_1d
     data = (0..5).to_a
     ds = Gnuplot::DataSet.new( data )
-    
+
     assert data == ds.data
     assert data.join("\n") + "\n", ds.to_gplot
+  end
+
+  def test_empty_array
+    data = []
+    ds = Gnuplot::DataSet.new( data )
+
+    assert data == ds.data
+    assert "" == ds.to_gplot
   end
 
 
@@ -20,10 +28,10 @@ class StdDataTest < Test::Unit::TestCase
     d1 = (0..3).to_a
     d2 = d1.collect { |v| 3 * v }
     d3 = d2.collect { |v| 4 * v }
-    
+
     data = [ d1, d2, d3 ]
     ds = Gnuplot::DataSet.new( data )
-    
+
     assert data == ds.data
     assert "0 0 0\n1 3 12\n2 6 24\n3 9 36\n", ds.to_gplot
   end
@@ -34,24 +42,24 @@ class DataSetTest < Test::Unit::TestCase
 
   def test_yield_ctor
     ds = Gnuplot::DataSet.new do |ds|
-      ds.with = "lines" 
+      ds.with = "lines"
       ds.using = "1:2"
       ds.data = [ [0, 1, 2], [1, 2, 5] ]
     end
-    
+
     assert "lines", ds.with
     assert "1:2",   ds.using
     assert nil == ds.title
     assert [ [0, 1, 2], [1, 2, 5] ] == ds.data
     assert "'-' using 1:2 with lines",  ds.plot_args
-    assert "0 1\n1 2\n2 5\n", ds.to_gplot 
+    assert "0 1\n1 2\n2 5\n", ds.to_gplot
   end
-  
+
 end
 
 
 class PlotTest < Test::Unit::TestCase
-  
+
   def test_no_data
     plot = Gnuplot::Plot.new do |p|
       p.set "output", "'foo'"
@@ -60,10 +68,10 @@ class PlotTest < Test::Unit::TestCase
     end
 
     assert( plot.settings ==
-		 [ [:set, "output", "'foo'"], 
+		 [ [:set, "output", "'foo'"],
 		   [:set, "terminal", "postscript enhanced"],
                    [:unset, "border"] ] )
-    
+
 
     assert( plot.to_gplot, \
 		 "set output 'foo'\nset terminal postscript enhanced\n" )
@@ -109,7 +117,7 @@ class PlotTest < Test::Unit::TestCase
       assert s2.index == 2, "index must be incremented"
 
       ds = Gnuplot::DataSet.new do |ds|
-        ds.with = "lines" 
+        ds.with = "lines"
         ds.linestyle = s1
         ds.data = [ [0, 1, 2], [1, 2, 5] ]
       end
@@ -134,7 +142,7 @@ class GnuplotModuleTest
 
   def test_which
     # Put the spaces around the command to make sure that it gets stripped
-    # properly. 
+    # properly.
     assert( CONFIG["SHELL"], Gnuplot::which(" sh " ) )
     assert( CONFIG["SHELL"], Gnuplot::which( CONFIG["SHELL"] ) )
   end
@@ -151,10 +159,10 @@ class GnuplotModuleTest
     # name (one that is in the path) then I should get the shell name as the
     # result of the gnuplot call.
 
-    ENV["RB_GNUPLOT"] = "sh" 
+    ENV["RB_GNUPLOT"] = "sh"
     assert( CONFIG["SHELL"], Gnuplot.gnuplot(false) )
   end
-      
+
 end
 
 


### PR DESCRIPTION
An empty array will now give the empty string when converted to Gnuplot data instead of triggering an error.
Note that Gnuplot will complain about empty datasets, but at least the wrapper will behave correctly.

Test case included.
