### PR TITLE
output verbose message to STDERR instead of STDOUT

### DIFF
--- a/lib/gnuplot.rb
+++ b/lib/gnuplot.rb
@@ -99,7 +99,7 @@ module Gnuplot
       @data = []
       @styles = []
       yield self if block_given?
-      puts "writing this to gnuplot:\n" + to_gplot + "\n" if $VERBOSE
+      $stderr.puts "writing this to gnuplot:\n" + to_gplot + "\n" if $VERBOSE
 
       if io
         io << to_gplot


### PR DESCRIPTION
Methinks verbose messages should be output to STDERR (the display channel) and not STDOUT (the data channel).
