### PR TITLE
Fix axis labels in example

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -111,8 +111,8 @@ Gnuplot.open do |gp|
   
     plot.xrange "[-10:10]"
     plot.title  "Sin Wave Example"
-    plot.ylabel "x"
-    plot.xlabel "sin(x)"
+    plot.xlabel "x"
+    plot.ylabel "sin(x)"
     
     plot.data << Gnuplot::DataSet.new( "sin(x)" ) do |ds|
       ds.with = "lines"


### PR DESCRIPTION
As far as I can tell, this is a mistake in the example. Does this seem better?