### PR TITLE
Fix docker gems install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ WORKDIR /home/gnuplot/gnuplot
 
 USER gnuplot
 
-COPY ./ ./
+COPY lib/ ./lib/
+COPY *.gemspec ./
+COPY Gemfile ./
 
 RUN gem install bundler; bundle install

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,7 @@ RUN useradd -u 1000 gnuplot; \
 WORKDIR /home/gnuplot/gnuplot
 
 USER gnuplot
-RUN gem install jeweler2
+
+COPY ./ ./
+
+RUN gem install bundler; bundle install


### PR DESCRIPTION
This is a fix to the Dockerfile based on the new gemspec format (introduced on #34)

Now, Dockerfile copies the needed files to run `bundle install`, then install all the gems