### PR TITLE
Fix Gnuplot::Plot#[]

### DIFF
--- a/lib/gnuplot.rb
+++ b/lib/gnuplot.rb
@@ -140,7 +140,7 @@ module Gnuplot
     # gnuplot process.
 
     def [] ( var )
-      v = @settings.rassoc( var )
+      v = @settings.reverse.rassoc( var )
       if v.nil? or v.first == :unset
           nil
       else


### PR DESCRIPTION
This PR fixes the method `Gnuplot::Plot#[]`

example:

```ruby
plot = Gnuplot::Plot.new do |p|
  p.title 'My Title'
  p.unset 'title'
end

plot['title'] # should return nil
```

The old code was fetching the first occurrence of `set title`

The tests for this are introduced in #52 